### PR TITLE
Improve code fixing Clippy warnings

### DIFF
--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -4,11 +4,11 @@ extern crate serde_json;
 use chrono::{DateTime, Utc};
 use std::io::{Error, ErrorKind};
 
-pub fn github_events(repo: String, token: Option<String>) -> Result<Vec<RawEvent>, Error> {
+pub fn github_events(repo: &str, token: Option<String>) -> Result<Vec<RawEvent>, Error> {
     let url = format!(
         "https://api.github.com/repos/{}/events?access_token={}&page=1",
         repo,
-        &token.unwrap_or("".to_string())
+        &token.unwrap_or_else(|| "".to_string())
     );
     let resp = reqwest::get(url.as_str());
     let mut resp = match resp {
@@ -25,7 +25,7 @@ pub fn github_events(repo: String, token: Option<String>) -> Result<Vec<RawEvent
             ))
         }
     };
-    let raw_events = raw_github_events(body);
+    let raw_events = raw_github_events(&body);
     let raw_events = match raw_events {
         Ok(events) => events,
         Err(_) => {
@@ -38,8 +38,8 @@ pub fn github_events(repo: String, token: Option<String>) -> Result<Vec<RawEvent
     Ok(raw_events)
 }
 
-fn raw_github_events(json: String) -> Result<Vec<RawEvent>, serde_json::Error> {
-    return serde_json::from_str::<Vec<RawEvent>>(&json);
+fn raw_github_events(json: &str) -> Result<Vec<RawEvent>, serde_json::Error> {
+    serde_json::from_str::<Vec<RawEvent>>(&json)
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq)]
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn parse_github_events() {
         assert_eq!(
-            raw_github_events(include_str!("../../test/github_events.json").to_string()).unwrap()
+            raw_github_events(include_str!("../../test/github_events.json")).unwrap()
                 [0],
             RawEvent {
                 actor: Actor {
@@ -144,14 +144,14 @@ mod tests {
     #[test]
     fn parse_real_github_events_from_nicokosi_pullpito() {
         let events =
-            raw_github_events(include_str!("../../test/pullpito_github_events.json").to_string());
+            raw_github_events(include_str!("../../test/pullpito_github_events.json"));
         assert!(events.is_ok());
     }
 
     #[test]
     fn parse_real_github_events_from_python_peps() {
         let events = raw_github_events(
-            include_str!("../../test/python_peps_github_events.json").to_string(),
+            include_str!("../../test/python_peps_github_events.json"),
         );
         assert!(events.is_ok());
     }


### PR DESCRIPTION
Fixed these [Clippy](https://github.com/rust-lang-nursery/rust-clippy) warnings:

warning: unneeded return statement
  --> src/github_events/mod.rs:42:5
   |
42 |     return serde_json::from_str::<Vec<RawEvent>>(&json);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `serde_json::from_str::<Vec<RawEvent>>(&json)`
   |
   = note: #[warn(needless_return)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_return

warning: unneeded return statement
  --> src/lib.rs:41:5
   |
41 | /     return events
42 | |         .into_iter()
43 | |         .filter(|e| {
44 | |             e.event_type == Type::PullRequestEvent
...  |
50 | |             acc
51 | |         });
   | |___________^
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_return
help: remove `return` as shown
   |
41 |     events
42 |         .into_iter()
43 |         .filter(|e| {
44 |             e.event_type == Type::PullRequestEvent
45 |                 || e.event_type == Type::PullRequestReviewCommentEvent
46 |                 || e.event_type == Type::IssueCommentEvent
 ...

warning: unneeded return statement
  --> src/lib.rs:92:5
   |
92 |     return out.to_string();
   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `out.to_string()`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_return

warning: this argument is passed by value, but not consumed in the function body
 --> src/github_events/mod.rs:7:28
  |
7 | pub fn github_events(repo: String, token: Option<String>) -> Result<Vec<RawEvent>, Error> {
  |                            ^^^^^^ help: consider changing the type to: `&str`
  |
  = note: #[warn(needless_pass_by_value)] on by default
  = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_pass_by_value

warning: use of `unwrap_or` followed by a function call
  --> src/github_events/mod.rs:11:16
   |
11 |         &token.unwrap_or("".to_string())
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "".to_string())`
   |
   = note: #[warn(or_fun_call)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#or_fun_call

warning: this argument is passed by value, but not consumed in the function body
  --> src/github_events/mod.rs:41:28
   |
41 | fn raw_github_events(json: String) -> Result<Vec<RawEvent>, serde_json::Error> {
   |                            ^^^^^^ help: consider changing the type to: `&str`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_pass_by_value

warning: use of `or_insert` followed by a function call
  --> src/lib.rs:49:52
   |
49 |             (*acc.entry(event.actor.login.clone()).or_insert(Vec::new())).push(event);
   |                                                    ^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(Vec::new)`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#or_fun_call

warning: this argument is passed by value, but not consumed in the function body
  --> src/lib.rs:54:20
   |
54 | fn printable(repo: String, events_per_author: HashMap<String, Vec<RawEvent>>) -> String {
   |                    ^^^^^^ help: consider changing the type to: `&str`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_pass_by_value

warning: this argument is passed by value, but not consumed in the function body
  --> src/lib.rs:54:47
   |
54 | fn printable(repo: String, events_per_author: HashMap<String, Vec<RawEvent>>) -> String {
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&HashMap<String, Vec<RawEvent>>`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#needless_pass_by_value

warning: it is more idiomatic to loop over references to containers instead of using explicit iteration methods
  --> src/lib.rs:57:29
   |
57 |     for (author, events) in events_per_author.iter() {
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&events_per_author`
   |
   = note: #[warn(explicit_iter_loop)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#explicit_iter_loop

warning: it is more idiomatic to loop over references to containers instead of using explicit iteration methods
  --> src/lib.rs:69:29
   |
69 |     for (author, events) in events_per_author.iter() {
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&events_per_author`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#explicit_iter_loop

warning: it is more idiomatic to loop over references to containers instead of using explicit iteration methods
  --> src/lib.rs:81:29
   |
81 |     for (author, events) in events_per_author.iter() {
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&events_per_author`
   |
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#explicit_iter_loop