### PR TITLE
🎨 Fix README warnings reported by markdownlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Command-line for GitHub pull request statistics, similar to [hubstats](https://g
 
 Implemented while learning [Rust](https://www.rust-lang.org/) 🦀, reading [The Rust Programming Language](https://doc.rust-lang.org/stable/book/second-edition/) 🎓.
 
-
 ## Pre-requisite
 
-Install the Rust toolchain via https://rustup.rs/.
+Install the [`rustup` Rust toolchain](https://rustup.rs/).
 
 ## Run
 
 In order to display pull request events for a **single** public GitHub repository, run `cargo --repository $org/$repo` or `cargo -r $org/$repo`.
 
 For instance, running `cargo run --quiet -- --repository python/peps` will display an output like:
-```
+
+```text
 pull requests for "python/peps" ->
   opened per author:
     ssbarnea: 1
@@ -24,7 +24,7 @@ pull requests for "python/peps" ->
   closed per author:
     brettcannon: 2
     gvanrossum: 6
-```
+ ```
 
 For a **private** GitHub repository, run `cargo run -- --repository $org/$repo --token $token`.
 
@@ -32,18 +32,15 @@ For **several** GitHub repositories, use several `repository` arguments: `cargo 
 
 For more information, run `cargo run -- --help`.
 
-
 ### Run with debug logs
 
 ```sh
 RUST_LOG=pullpito=debug cargo run -- --repository nicokosi/pullpito
 ```
 
-
 ## Install
 
 Run `cargo install --path .`. You can then run the `pullpito` command directly.
-
 
 ## Development cheat-sheet
 


### PR DESCRIPTION
MD012/no-multiple-blanks: Multiple consecutive blank lines [Expected: 1; Actual: 2]
MD034/no-bare-urls: Bare URL used
MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank lines
MD040/fenced-code-language: Fenced code blocks should have a language specified
MD047/single-trailing-newline: Files should end with a single newline character