### PR TITLE
Write idiomatic code in edition 2018

### DIFF
--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -1,6 +1,6 @@
-extern crate regex;
-extern crate reqwest;
-extern crate serde_json;
+use regex;
+use reqwest;
+use serde_json;
 
 use self::reqwest::StatusCode;
 use chrono::{DateTime, Utc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-extern crate chrono;
-extern crate env_logger;
-extern crate futures;
+
+
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate regex;
+
 #[macro_use]
 extern crate serde_derive;
-extern crate structopt;
+
 
 use crate::github_events::{github_events as _github_events, Action, RawEvent, Type};
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ use std::thread;
 use structopt::StructOpt;
 
 pub mod github_events;
-extern crate serde;
+
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-extern crate clap;
-extern crate env_logger;
+
+use env_logger;
 #[macro_use]
 extern crate log;
-extern crate pullpito;
+use pullpito;
 
 use std::env;
 


### PR DESCRIPTION
Code automatically updated via:

  $ cargo fix --edition-idioms

See https://doc.rust-lang.org/nightly/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html#writing-idiomatic-code-in-a-new-edition