### PR TITLE
👷 Deactivate code coverage to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ addons:
       - kalakris-cmake
 
 before_script:
-  - cargo install --force cargo-travis
   - export PATH=$HOME/.cargo/bin:$PATH
+#  - cargo install --force cargo-travis
   - rustup component add rustfmt-preview
 
 script:
@@ -30,7 +30,7 @@ script:
   - cargo test
 
 after_success:
-  - cargo coveralls
+#  - cargo coveralls
 
 env:
   global:


### PR DESCRIPTION
cargo install cargo-travis

fails with:

	error[E0277]: a value of type `[_]` cannot be built from an iterator over elements of type `std::path::PathBuf`

	   --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-travis-0.0.11/src/lib.rs:307:53

	    |

	307 |             &doc.map(|entry| entry.unwrap().path()).collect(),

	    |                                                     ^^^^^^^ value of type `[_]` cannot be built from `std::iter::Iterator<Item=std::path::PathBuf>`

	    |

	    = help: the trait `std::iter::FromIterator<std::path::PathBuf>` is not implemented for `[_]`

Seems related to Cargo 1.46.
I hope to reactivate code coverage soon.