### PR TITLE
Fix pedantic Clippy lints 🎨

### DIFF
--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -25,28 +25,26 @@ pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>
                 if body.len() <= "[]".len() {
                     debug!("No more content for {:?} (page number: {})", repo, page);
                     break;
-                } else {
-                    debug!("Content found for {:?} (page number: {})", repo, page);
-                    trace!(
-                        "Content found for {:?} (page number: {}): {:?}",
-                        repo,
-                        page,
-                        body
-                    );
-                    body
                 }
+                debug!("Content found for {:?} (page number: {})", repo, page);
+                trace!(
+                    "Content found for {:?} (page number: {}): {:?}",
+                    repo,
+                    page,
+                    body
+                );
+                body
             }
             Err(error) => {
                 if let Some(reqwest::StatusCode::UNPROCESSABLE_ENTITY) = error.status() {
                     debug!("No more content for {:?} (page number: {})", repo, page);
                     break;
-                } else {
-                    debug!("Oops, something went wrong with GitHub API {:?}", error);
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        format!("Cannot get GitHub API content: {}", error),
-                    ));
                 }
+                debug!("Oops, something went wrong with GitHub API {:?}", error);
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!("Cannot get GitHub API content: {}", error),
+                ));
             }
         };
 

--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer};
 use std::io::{Error, ErrorKind};
 use std::str;
 
-pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
+pub(crate) fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
     let mut raw_events: Vec<RawEvent> = Vec::new();
     for page in 1..10 {
         let token = token.clone();

--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -132,7 +132,7 @@ fn deserialize_field_action<'de, D>(deserializer: D) -> Result<Action, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(Action::deserialize(deserializer).unwrap_or(Action::Unknown))
+    Action::deserialize(deserializer).or(Ok(Action::Unknown))
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq)]
@@ -153,7 +153,7 @@ fn deserialize_field_type<'de, D>(deserializer: D) -> Result<Type, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(Type::deserialize(deserializer).unwrap_or(Type::Unknown))
+    Type::deserialize(deserializer).or(Ok(Type::Unknown))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,11 @@ fn config_from_args(args: Vec<OsString>) -> Config {
     }
 }
 
+/// Calls GitHub REST API in order to log pull requests' statistics in the standard output.
+///
+/// # Panics
+///
+/// Panics if the GitHub API request fails or if response cannot be deserialized.
 pub fn log_github_events(os: Vec<OsString>) {
     env_logger::init();
     let config = config_from_args(os);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,5 @@
-use log::info;
-
 use std::env;
 
 fn main() {
-    env_logger::init();
-    let config = pullpito::config_from_args(env::args_os().collect());
-    info!(
-        "Computing stats for GitHub repos '{:?}' (with token: {})",
-        config.repos,
-        config.token.is_some()
-    );
-    pullpito::github_events(config);
+    pullpito::log_github_events(env::args_os().collect());
 }


### PR DESCRIPTION
As suggested in the [`How not to learn Rust` blog post](https://dystroy.org/blog/how-not-to-learn-rust/):

> while you're at it, run cargo clippy from time to time

Lints seen via:

    cargo clippy -- -W clippy::pedantic

- [x] warning: redundant else block --> src/github_events/mod.rs:28:24
- [x] warning: redundant else block --> src/github_events/mod.rs:43:24
- [x] warning: docs for function which may panic missing `# Panics` section --> src/github_events/mod.rs:10:1
- [x] warning: docs for function returning `Result` missing `# Errors` section --> src/github_events/mod.rs:10:1
- [x] warning: this function's return value is unnecessarily wrapped by `Result` --> src/github_events/mod.rs:133:1
- [x] warning: this function's return value is unnecessarily wrapped by `Result` --> src/github_events/mod.rs:154:1
- [x] warning: this function could have a `#[must_use]` attribute --> src/lib.rs:46:1
- [x] warning: docs for function which may panic missing `# Panics` section --> src/lib.rs:54:1

Before fixes:
```sh
~/work/pullpito • cargo clippy -- -W clippy::pedantic
    Checking pullpito v0.1.0 (/Users/nicolas/work/pullpito)
warning: redundant else block
  --> src/github_events/mod.rs:28:24
   |
28 |                   } else {
   |  ________________________^
29 | |                     debug!("Content found for {:?} (page number: {})", repo, page);
30 | |                     trace!(
31 | |                         "Content found for {:?} (page number: {}): {:?}",
...  |
36 | |                     body
37 | |                 }
   | |_________________^
   |
   = note: `-W clippy::redundant-else` implied by `-W clippy::pedantic`
   = help: remove the `else` block and move the contents out
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else

warning: redundant else block
  --> src/github_events/mod.rs:43:24
   |
43 |                   } else {
   |  ________________________^
44 | |                     debug!("Oops, something went wrong with GitHub API {:?}", error);
45 | |                     return Err(Error::new(
46 | |                         ErrorKind::Other,
47 | |                         format!("Cannot get GitHub API content: {}", error),
48 | |                     ));
49 | |                 }
   | |_________________^
   |
   = help: remove the `else` block and move the contents out
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else

warning: docs for function which may panic missing `# Panics` section
  --> src/github_events/mod.rs:10:1
   |
10 | / pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
11 | |     let mut raw_events: Vec<RawEvent> = Vec::new();
12 | |     for page in 1..10 {
13 | |         let token = token.clone();
...  |
75 | |     Ok(raw_events)
76 | | }
   | |_^
   |
   = note: `-W clippy::missing-panics-doc` implied by `-W clippy::pedantic`
note: first possible panic found here
  --> src/github_events/mod.rs:61:60
   |
61 |                 let last_page = last_page_from_link_header(str::from_utf8(link_header).unwrap());
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc

warning: docs for function returning `Result` missing `# Errors` section
  --> src/github_events/mod.rs:10:1
   |
10 | / pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
11 | |     let mut raw_events: Vec<RawEvent> = Vec::new();
12 | |     for page in 1..10 {
13 | |         let token = token.clone();
...  |
75 | |     Ok(raw_events)
76 | | }
   | |_^
   |
   = note: `-W clippy::missing-errors-doc` implied by `-W clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc

warning: this function's return value is unnecessarily wrapped by `Result`
   --> src/github_events/mod.rs:133:1
    |
133 | / fn deserialize_field_action<'de, D>(deserializer: D) -> Result<Action, D::Error>
134 | | where
135 | |     D: Deserializer<'de>,
136 | | {
137 | |     Ok(Action::deserialize(deserializer).unwrap_or(Action::Unknown))
138 | | }
    | |_^
    |
    = note: `-W clippy::unnecessary-wraps` implied by `-W clippy::pedantic`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
help: remove `Result` from the return type...
    |
133 | fn deserialize_field_action<'de, D>(deserializer: D) -> github_events::Action
    |                                                         ~~~~~~~~~~~~~~~~~~~~~
help: ...and then change returning expressions
    |
137 |     Action::deserialize(deserializer).unwrap_or(Action::Unknown)
    |

warning: this function's return value is unnecessarily wrapped by `Result`
   --> src/github_events/mod.rs:154:1
    |
154 | / fn deserialize_field_type<'de, D>(deserializer: D) -> Result<Type, D::Error>
155 | | where
156 | |     D: Deserializer<'de>,
157 | | {
158 | |     Ok(Type::deserialize(deserializer).unwrap_or(Type::Unknown))
159 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
help: remove `Result` from the return type...
    |
154 | fn deserialize_field_type<'de, D>(deserializer: D) -> github_events::Type
    |                                                       ~~~~~~~~~~~~~~~~~~~
help: ...and then change returning expressions
    |
158 |     Type::deserialize(deserializer).unwrap_or(Type::Unknown)
    |

warning: this function could have a `#[must_use]` attribute
  --> src/lib.rs:46:1
   |
46 | pub fn config_from_args(args: Vec<OsString>) -> Config {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn config_from_args(args: Vec<OsString>) -> Config`
   |
   = note: `-W clippy::must-use-candidate` implied by `-W clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate

warning: docs for function which may panic missing `# Panics` section
  --> src/lib.rs:54:1
   |
54 | / pub fn github_events(config: Config) {
55 | |     let (sender, receiver) = mpsc::channel();
56 | |     let number_of_repos = config.repos.len();
57 | |
...  |
79 | |     }
80 | | }
   | |_^
   |
note: first possible panic found here
  --> src/lib.rs:63:13
   |
63 | /             sender
64 | |                 .send(RepoEvents {
65 | |                     repo: repo.clone(),
66 | |                     events_per_author: events_per_author(_github_events(&repo, &token).unwrap()),
67 | |                 })
68 | |                 .unwrap();
   | |_________________________^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc

warning: `pullpito` (lib) generated 8 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.98s
                               --   --   (master  origin)     
~/work/pullpito •                                                                                                                                                     6:26  nicolas@MacBook-Pro-de-NicolasK
                               --   --   (master  origin)     
~/work/pullpito • cargo clippy -- -W clippy::pedantic                                                                                                                 6:26  nicolas@MacBook-Pro-de-NicolasK
warning: redundant else block
  --> src/github_events/mod.rs:28:24
   |
28 |                   } else {
   |  ________________________^
29 | |                     debug!("Content found for {:?} (page number: {})", repo, page);
30 | |                     trace!(
31 | |                         "Content found for {:?} (page number: {}): {:?}",
...  |
36 | |                     body
37 | |                 }
   | |_________________^
   |
   = note: `-W clippy::redundant-else` implied by `-W clippy::pedantic`
   = help: remove the `else` block and move the contents out
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else

warning: redundant else block
  --> src/github_events/mod.rs:43:24
   |
43 |                   } else {
   |  ________________________^
44 | |                     debug!("Oops, something went wrong with GitHub API {:?}", error);
45 | |                     return Err(Error::new(
46 | |                         ErrorKind::Other,
47 | |                         format!("Cannot get GitHub API content: {}", error),
48 | |                     ));
49 | |                 }
   | |_________________^
   |
   = help: remove the `else` block and move the contents out
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else

warning: docs for function which may panic missing `# Panics` section
  --> src/github_events/mod.rs:10:1
   |
10 | / pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
11 | |     let mut raw_events: Vec<RawEvent> = Vec::new();
12 | |     for page in 1..10 {
13 | |         let token = token.clone();
...  |
75 | |     Ok(raw_events)
76 | | }
   | |_^
   |
   = note: `-W clippy::missing-panics-doc` implied by `-W clippy::pedantic`
note: first possible panic found here
  --> src/github_events/mod.rs:61:60
   |
61 |                 let last_page = last_page_from_link_header(str::from_utf8(link_header).unwrap());
   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc

warning: docs for function returning `Result` missing `# Errors` section
  --> src/github_events/mod.rs:10:1
   |
10 | / pub fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<RawEvent>, Error> {
11 | |     let mut raw_events: Vec<RawEvent> = Vec::new();
12 | |     for page in 1..10 {
13 | |         let token = token.clone();
...  |
75 | |     Ok(raw_events)
76 | | }
   | |_^
   |
   = note: `-W clippy::missing-errors-doc` implied by `-W clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc

warning: this function's return value is unnecessarily wrapped by `Result`
   --> src/github_events/mod.rs:133:1
    |
133 | / fn deserialize_field_action<'de, D>(deserializer: D) -> Result<Action, D::Error>
134 | | where
135 | |     D: Deserializer<'de>,
136 | | {
137 | |     Ok(Action::deserialize(deserializer).unwrap_or(Action::Unknown))
138 | | }
    | |_^
    |
    = note: `-W clippy::unnecessary-wraps` implied by `-W clippy::pedantic`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
help: remove `Result` from the return type...
    |
133 | fn deserialize_field_action<'de, D>(deserializer: D) -> github_events::Action
    |                                                         ~~~~~~~~~~~~~~~~~~~~~
help: ...and then change returning expressions
    |
137 |     Action::deserialize(deserializer).unwrap_or(Action::Unknown)
    |

warning: this function's return value is unnecessarily wrapped by `Result`
   --> src/github_events/mod.rs:154:1
    |
154 | / fn deserialize_field_type<'de, D>(deserializer: D) -> Result<Type, D::Error>
155 | | where
156 | |     D: Deserializer<'de>,
157 | | {
158 | |     Ok(Type::deserialize(deserializer).unwrap_or(Type::Unknown))
159 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
help: remove `Result` from the return type...
    |
154 | fn deserialize_field_type<'de, D>(deserializer: D) -> github_events::Type
    |                                                       ~~~~~~~~~~~~~~~~~~~
help: ...and then change returning expressions
    |
158 |     Type::deserialize(deserializer).unwrap_or(Type::Unknown)
    |

warning: this function could have a `#[must_use]` attribute
  --> src/lib.rs:46:1
   |
46 | pub fn config_from_args(args: Vec<OsString>) -> Config {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn config_from_args(args: Vec<OsString>) -> Config`
   |
   = note: `-W clippy::must-use-candidate` implied by `-W clippy::pedantic`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate

warning: docs for function which may panic missing `# Panics` section
  --> src/lib.rs:54:1
   |
54 | / pub fn github_events(config: Config) {
55 | |     let (sender, receiver) = mpsc::channel();
56 | |     let number_of_repos = config.repos.len();
57 | |
...  |
79 | |     }
80 | | }
   | |_^
   |
note: first possible panic found here
  --> src/lib.rs:63:13
   |
63 | /             sender
64 | |                 .send(RepoEvents {
65 | |                     repo: repo.clone(),
66 | |                     events_per_author: events_per_author(_github_events(&repo, &token).unwrap()),
67 | |                 })
68 | |                 .unwrap();
   | |_________________________^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc

warning: `pullpito` (lib) generated 8 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
```