### PR TITLE
Fix Clippy lints `format!(..)` appended to existing `String` 🎨

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
+use std::fmt::Write as _;
 use std::str;
 use std::sync::mpsc;
 use std::thread;
@@ -128,7 +129,7 @@ fn printable(repo: &str, events_per_author: &HashMap<String, Vec<RawEvent>>) -> 
             })
             .count();
         if opened_pull_requests > 0 {
-            out.push_str(&format!("    {}: {}\n", author, opened_pull_requests));
+            let _ = writeln!(out, "    {}: {}", author, opened_pull_requests);
         }
     }
     out.push_str("  commented per author:\n");
@@ -140,7 +141,7 @@ fn printable(repo: &str, events_per_author: &HashMap<String, Vec<RawEvent>>) -> 
             })
             .count();
         if commented_pull_requests > 0 {
-            out.push_str(&format!("    {}: {}\n", author, commented_pull_requests));
+            let _ = writeln!(out, "    {}: {}", author, commented_pull_requests);
         }
     }
     out.push_str("  closed per author:\n");
@@ -152,7 +153,7 @@ fn printable(repo: &str, events_per_author: &HashMap<String, Vec<RawEvent>>) -> 
             })
             .count();
         if closed_pull_requests > 0 {
-            out.push_str(&format!("    {}: {}\n", author, closed_pull_requests));
+            let _ = writeln!(out, "    {}: {}", author, closed_pull_requests);
         }
     }
     out


### PR DESCRIPTION
After fix:

    $ cargo clippy
    Checking pullpito v0.1.1 (/Users/nicolas/work/pullpito)
    Finished dev [unoptimized + debuginfo] target(s) in 0.87s

Before fix:

    $ cargo clippy
    Checking pullpito v0.1.1 (/Users/nicolas/work/pullpito)
    warning: `format!(..)` appended to existing `String`
       --> src/lib.rs:131:13
        |
    131 |             out.push_str(&format!("    {}: {}\n", author, opened_pull_requests));
        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: `#[warn(clippy::format_push_string)]` on by default
        = help: consider using `write!` to avoid the extra allocation
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

    warning: `format!(..)` appended to existing `String`
       --> src/lib.rs:143:13
        |
    143 |             out.push_str(&format!("    {}: {}\n", author, commented_pull_requests));
        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = help: consider using `write!` to avoid the extra allocation
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

    warning: `format!(..)` appended to existing `String`
       --> src/lib.rs:155:13
        |
    155 |             out.push_str(&format!("    {}: {}\n", author, closed_pull_requests));
        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = help: consider using `write!` to avoid the extra allocation
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string

    warning: `pullpito` (lib) generated 3 warnings
    warning: `pullpito` (lib test) generated 3 warnings (3 duplicates)