### PR TITLE
Fix Clippy warning: deriving `PartialEq` and can implement `Eq` ⚠️

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::github_events::{github_events as _github_events, Action, RawEvent, Ty
 
 pub mod github_events;
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Config {
     pub repos: Vec<String>,
     pub token: Option<String>,


### PR DESCRIPTION
By the way, equality is only used in tests. 💭

Before:

	$ cargo clippy
	[...]
	warning: you are deriving `PartialEq` and can implement `Eq`
	  --> src/lib.rs:18:30
	   |
	18 | #[derive(Debug, Deserialize, PartialEq, Serialize)]
	   |                              ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
	   |
	   = note: `#[warn(clippy::derive_partial_eq_without_eq)]` on by default
	   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

	warning: `pullpito` (lib) generated 1 warning

Now:

	$ cargo clippy
	    Checking pullpito v0.1.1 (/Users/nicolas/work/pullpito)
	    Finished dev [unoptimized + debuginfo] target(s) in 1.96s