### PR TITLE
Fix #127: Remove Clippy 'nursery' lint warnings 🚨

### DIFF
--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -41,7 +41,7 @@ pub(crate) fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<Ra
                 body
             }
             Err(error) => {
-                if let Some(reqwest::StatusCode::UNPROCESSABLE_ENTITY) = error.status() {
+                if error.status() == Some(reqwest::StatusCode::UNPROCESSABLE_ENTITY) {
                     debug!("No more content for {:?} (page number: {})", repo, page);
                     break;
                 }
@@ -129,8 +129,8 @@ pub enum Action {
     Unknown,
 }
 impl Action {
-    fn default() -> Self {
-        Action::Unknown
+    const fn default() -> Self {
+        Self::Unknown
     }
 }
 
@@ -150,8 +150,8 @@ pub enum Type {
     Unknown,
 }
 impl Type {
-    fn default() -> Self {
-        Type::Unknown
+    const fn default() -> Self {
+        Self::Unknown
     }
 }
 


### PR DESCRIPTION
See Clippy references 📖:
https://rust-lang.github.io/rust-clippy/master/index.html#equatable_if_let
https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn
https://rust-lang.github.io/rust-clippy/master/index.html#use_self