### PR TITLE
Add a `TRACE` log for HTTP queries to github.com 🔎

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ For **several** GitHub repositories, use several `repository` arguments: `cargo 
 
 For more information, run `cargo run -- --help`.
 
-### Run with debug logs
+### Run with debug/trace logs
 
+Log level can be changed via the `RUST_LOG` environment variable.
+
+`DEBUG` logs add some internal info. They can be activated this way:
 ```sh
 RUST_LOG=pullpito=debug cargo run -- --repository nicokosi/pullpito
+```
+
+`TRACE` logs are more detailed and contain sensitive data like the GitHub token. They can be activated this way:
+```sh
+RUST_LOG=pullpito=trace cargo run -- --repository nicokosi/pullpito
 ```
 
 ## Install

--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -20,6 +20,7 @@ pub(crate) fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<Ra
             value.push_str(&token.unwrap_or_default());
             headers.insert(header::AUTHORIZATION, value.parse().unwrap());
         }
+        trace!("GET {}\n  headers: {:?}", url.as_str(), headers);
         let mut resp = reqwest::Client::new()
             .get(url.as_str())
             .headers(headers)


### PR DESCRIPTION
In order to ease GitHub API troubleshooting, add a TRACE log for HTTP queries:

    $ RUST_LOG=pullpito=trace cargo run -- --repository nicokosi/pullpitoK --token 1234
       Compiling pullpito v0.1.1 (/Users/nicolas/work/pullpito)
        Finished dev [unoptimized + debuginfo] target(s) in 5.11s
         Running `target/debug/pullpito --repository nicokosi/pullpitoK --token 1234`
    [2023-04-26T05:16:06Z INFO  pullpito] Computing stats for GitHub repos '["nicokosi/pullpitoK"]' (with token: true)
    [2023-04-26T05:16:06Z DEBUG pullpito] Query stats for GitHub repo "nicokosi/pullpitoK"
    [2023-04-26T05:16:06Z TRACE pullpito::github_events] GET https://api.github.com/repos/nicokosi/pullpitoK/events?page=1
          headers: {"authorization": "token 1234"}