### PR TITLE
*Always* add mandatory 'user-agent' HTTP header 😇

### DIFF
--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -15,11 +15,11 @@ pub(crate) fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<Ra
         let token = token.clone();
         let url = format!("https://api.github.com/repos/{repo}/events?page={page}");
         let mut headers = header::HeaderMap::new();
+        headers.insert(header::USER_AGENT, "nicokosi/pullpito".parse().unwrap());
         if token.is_some() {
             let mut value = "token ".to_string();
             value.push_str(&token.unwrap_or_default());
             headers.insert(header::AUTHORIZATION, value.parse().unwrap());
-            headers.insert(header::USER_AGENT, "nicokosi/pullpito".parse().unwrap());
         }
         trace!("GET {}\n  headers: {:?}", url.as_str(), headers);
         let resp = reqwest::blocking::Client::new()


### PR DESCRIPTION
b9e2f2b485091357b0f084934fe2ad8a3780a02f only added 'user-agent' HTTP header if token was provided:

	RUST_LOG=pullpito=trace cargo run -- --repository nicokosi/pullpito
	    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
	     Running `target/debug/pullpito --repository nicokosi/pullpito`
	[2023-05-15T03:17:33Z INFO  pullpito] Computing stats for GitHub repos '["nicokosi/pullpito"]' (with token: false)
	[2023-05-15T03:17:33Z DEBUG pullpito] Query stats for GitHub repo "nicokosi/pullpito"
	[2023-05-15T03:17:33Z TRACE pullpito::github_events] GET https://api.github.com/repos/nicokosi/pullpito/events?page=1
	      headers: {}

This commits adds the 'user-agent' HTTP header in all cases.