### PR TITLE
Fix `explicit_iter_loop` pedantic lint 🎨

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ fn print_pull_request_events_per_author(
     payload_action: &Action,
     out: &mut String,
 ) {
-    for (author, events) in events_per_author.iter() {
+    for (author, events) in events_per_author {
         let matching_pull_requests = events
             .iter()
             .filter(|e| {


### PR DESCRIPTION
Lint warning, before this change:

	$ cargo clippy

	140 |     for (author, events) in events_per_author.iter() {
	    |                             ^^^^^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `events_per_author`
	    |
	    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop
	    = note: `-W clippy::explicit-iter-loop` implied by `-W clippy::pedantic`

	warning: `pullpito` (lib) generated 1 warning (run `cargo clippy --fix --lib -p pullpito` to apply 1 suggestion)