### PR TITLE
🚨 Fix Clippy error `use_or_insert_with`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,10 +110,7 @@ fn events_per_author(events: Vec<RawEvent>) -> HashMap<String, Vec<RawEvent>> {
                 || e.event_type == Type::IssueCommentEvent
         })
         .fold(HashMap::new(), |mut acc, event: RawEvent| {
-            (*acc
-                .entry(event.actor.login.clone())
-                .or_insert_with(Vec::new))
-            .push(event);
+            (*acc.entry(event.actor.login.clone()).or_default()).push(event);
             acc
         })
 }


### PR DESCRIPTION
Fixes CI failing with commit 6db50491947532eaa132387b469f337e48cd2e54:

	error: use of `or_insert_with` to construct default value
	Error:    --> src/lib.rs:115:18
	    |
	115 |                 .or_insert_with(Vec::new))
	    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
	    |
	    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
	    = note: `-D clippy::unwrap-or-default` implied by `-D warnings`

https://github.com/nicokosi/pullpito/actions/runs/6887187730/job/18733990115

Seems related to Cargo 1.73 update.

I had to uninstall Hombrew-installed Rust to reproduce locally:

	brew rm rust # Cargo 1.72.1