### PR TITLE
Unblock CI using a non-deprecated Actions runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out ⬅️

--- a/src/github_events/mod.rs
+++ b/src/github_events/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 use std::str;
 
 use chrono::{DateTime, Utc};
@@ -47,10 +47,9 @@ pub(crate) fn github_events(repo: &str, token: &Option<String>) -> Result<Vec<Ra
                     break;
                 }
                 debug!("Oops, something went wrong with GitHub API {:?}", error);
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!("Cannot get GitHub API content: {error}"),
-                ));
+                return Err(Error::other(format!(
+                    "Cannot get GitHub API content: {error}"
+                )));
             }
         };
 


### PR DESCRIPTION
CI is blocked since `ubuntu-20.04` Actions runner image is deprecated. Let's use `ubuntu-22.04` runner image! https://github.com/actions/runner-images/issues/11101