### PR TITLE
Do not run doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ reqwest = { version = "0.12", features = ["blocking"] }
 structopt = "0.3"
 regex = "1.10"
 lazy_static = "1.4"
+
+[lib]
+doctest = false


### PR DESCRIPTION
Prevents this output when running `cargo test`:

	   Doc-tests pullpito

	running 0 tests

	test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

See Cargo Book about the Manifest format:
https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=doctest#the-doctest-field
